### PR TITLE
Add a "meta" RFC for our RFC process!

### DIFF
--- a/000-rfcs.md
+++ b/000-rfcs.md
@@ -1,0 +1,25 @@
+
+# RFCs
+
+We want to start using RFCs to discuss (and document) architectural decisions.
+
+**Discussion:** Link the PR introducing this RFC here!
+
+## Problem
+
+Ideas tend to get stuck in one person's head by default (or lost in 1:1 conversations). As our team grows, we want to make it easy for everyone to take part in architectural discussions & see where we're thinking about taking our platform.
+
+## Proposal
+
+We should adopt a simple RFC process, inspired by the process used by the engineering teams at [Artsy](https://artsy.github.io/blog/2019/04/11/on-an-rfcs-process/) and [GOV.UK](https://github.com/alphagov/govuk-rfcs) and on larger open-source projects like [React](https://github.com/reactjs/rfcs) or [Rust](https://github.com/rust-lang/rfcs). (And while their namesake comes from the [exhaustive IETF standards documents](https://www.rfc-editor.org/rfc-index.html), we definetely don't want to replicate that!)
+
+By documenting architectural goals in a semi-formal manner like this, we hope to increase transparency (since a public document is by definition a lot more transparent than one-one-one discussions). We're also hoping this reduces friction by helping to spread ideas _before_ the pull request review process.
+
+I'd recommend we start with a [very lightweight process](https://github.com/DoSomething/rfcs/tree/hello-rfcs#process) and introduce more rules over time.
+
+## Drawbacks/Alternatives
+
+Two possible downsides to this process are the creation of additional "busywork" (talking about doing the work, rather than "just doing it") and potentially reinforcing that the "loudest voice wins" (see [this section of Artsy's blog post](https://artsy.github.io/blog/2019/04/11/on-an-rfcs-process/#What.are.the.alternatives.)). Personally, I think in both cases we're better off with _some_ process than none though!
+
+We could also use our existing [opportunity assessment](https://docs.google.com/document/d/1KCl9MadAftdNxPYx_zuuWTYW25lgyqZkAM2vSXVH6T4/edit) template for discussions like this (and have done so in the past)! However, I think that process is better suited for product ideas than ongoing architectural approaches.
+

--- a/001-rfcs.md
+++ b/001-rfcs.md
@@ -7,7 +7,7 @@ We want to start using RFCs to discuss (and document) architectural decisions.
 
 ## Problem
 
-Ideas tend to get stuck in one person's head by default (or lost in 1:1 conversations). As our team grows, we want to make it easy for everyone to take part in architectural discussions & see where we're thinking about taking our platform.
+Ideas tend to get stuck in one person's head by default (or lost in 1:1 conversations). As our team grows, we want to make it easy for everyone to take part in architectural/process discussions & see ideas we've committed to trying.
 
 ## Proposal
 

--- a/001-rfcs.md
+++ b/001-rfcs.md
@@ -3,7 +3,7 @@
 
 We want to start using RFCs to discuss (and document) architectural decisions.
 
-**Discussion:** Link the PR introducing this RFC here!
+**Discussion:** https://github.com/DoSomething/rfcs/pull/1
 
 ## Problem
 

--- a/001-rfcs.md
+++ b/001-rfcs.md
@@ -13,7 +13,7 @@ Ideas tend to get stuck in one person's head by default (or lost in 1:1 conversa
 
 We should adopt a simple RFC process, inspired by the process used by the engineering teams at [Artsy](https://artsy.github.io/blog/2019/04/11/on-an-rfcs-process/) and [GOV.UK](https://github.com/alphagov/govuk-rfcs) and on larger open-source projects like [React](https://github.com/reactjs/rfcs) or [Rust](https://github.com/rust-lang/rfcs). (And while their namesake comes from the [exhaustive IETF standards documents](https://www.rfc-editor.org/rfc-index.html), we definitely don't want to replicate that!)
 
-By documenting architectural goals in a semi-formal manner like this, we hope to increase transparency (since a public document is by definition a lot more transparent than one-one-one discussions). We're also hoping this reduces friction by helping to spread ideas _before_ the pull request review process.
+By documenting architectural goals in a semi-formal manner like this, we hope to increase transparency (since a public document is by definition a lot more transparent than 1:1 discussions). We're also hoping this reduces friction by helping to spread ideas _before_ the pull request review process.
 
 I'd recommend we start with a [very lightweight process](https://github.com/DoSomething/rfcs/tree/hello-rfcs#process) and introduce more rules over time.
 

--- a/001-rfcs.md
+++ b/001-rfcs.md
@@ -11,7 +11,7 @@ Ideas tend to get stuck in one person's head by default (or lost in 1:1 conversa
 
 ## Proposal
 
-We should adopt a simple RFC process, inspired by the process used by the engineering teams at [Artsy](https://artsy.github.io/blog/2019/04/11/on-an-rfcs-process/) and [GOV.UK](https://github.com/alphagov/govuk-rfcs) and on larger open-source projects like [React](https://github.com/reactjs/rfcs) or [Rust](https://github.com/rust-lang/rfcs). (And while their namesake comes from the [exhaustive IETF standards documents](https://www.rfc-editor.org/rfc-index.html), we definetely don't want to replicate that!)
+We should adopt a simple RFC process, inspired by the process used by the engineering teams at [Artsy](https://artsy.github.io/blog/2019/04/11/on-an-rfcs-process/) and [GOV.UK](https://github.com/alphagov/govuk-rfcs) and on larger open-source projects like [React](https://github.com/reactjs/rfcs) or [Rust](https://github.com/rust-lang/rfcs). (And while their namesake comes from the [exhaustive IETF standards documents](https://www.rfc-editor.org/rfc-index.html), we definitely don't want to replicate that!)
 
 By documenting architectural goals in a semi-formal manner like this, we hope to increase transparency (since a public document is by definition a lot more transparent than one-one-one discussions). We're also hoping this reduces friction by helping to spread ideas _before_ the pull request review process.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use a very streamlined version to discuss architectural & process changes within
 **Note:** We'll evolve this process over time! See `001-rfcs.md` for ongoing discussion.
 1. Create a new branch on this repo and copy `000-template.md` to `000-my-proposal.md` and fill out the template.
 2. Create a pull request. GitHub will automatically post a notification in [#announce-tech](https://app.slack.com/client/T024GV2BW/C782XBKDM) so others can review it. 
-3. Rename your proposal based on the PR's number (e.g. for [#1](https://github.com/DoSomething/rfcs/pulls/1), we'd name the file `001-rfcs.md`).
+3. Rename your proposal based on the PR's number (e.g. for [#1](https://github.com/DoSomething/rfcs/pull/1), we'd name the file `001-rfcs.md`).
 4. Once we've reached consensus (loosely defined as four approvals), merge in your RFC!
 
 <br/><br/>


### PR DESCRIPTION
This pull request introduces the "RFCs" RFC:

> We want to start using RFCs to discuss (and document) architectural decisions.

## Open Questions
- How do folks feel about the template? I wanted to keep it as lightweight as possible, while also giving a clear outline for things that are worth mentioning in a "good" RFC. Anything I missed?
- How do folks feel about the suggested process (see `README.md`)?

